### PR TITLE
fix xss in articles search bar

### DIFF
--- a/app/backend/controllers/ArticlesController.php
+++ b/app/backend/controllers/ArticlesController.php
@@ -26,7 +26,7 @@ class ArticlesController extends BaseController{
     public function indexAction(){
         $page = intval($this -> request -> get('page', 'trim'));
         $cid = intval($this -> request -> get('cid', 'trim'));
-        $keyword = $this -> request -> get('keyword', 'trim');
+        $keyword = $this -> request -> get('keyword', 'remove_xss');
         /**分页获取文章列表*/
         $pagesize = 10;
         $paginator = $this -> get_repository('Articles') -> get_list($page, $pagesize, array(


### PR DESCRIPTION
Hi, I find this CMS in [https://github.com/phalcon/awesome-phalcon](awesome-phalcon), great job for the repo!
When I test the cms , I find xss in articles search bar just like this :
Location:
![image](https://user-images.githubusercontent.com/42600601/105635806-f5b4a600-5e9f-11eb-9d2a-3eb8da0e51aa.png)
XSS poc:
![image](https://user-images.githubusercontent.com/42600601/105635844-33193380-5ea0-11eb-9d8c-350529ec0183.png)
I got xss when search `"><ScRiPt>alert(document.cookie)</ScRiPt>`
When i read the code, I find the way to fix it, so I open this pull request.